### PR TITLE
fix the link to a section within the org file

### DIFF
--- a/README.org
+++ b/README.org
@@ -585,8 +585,8 @@ This sub-hierarchy is here to test specific stuff.
 - [[me@server.com][indirect email]]
 - [[file:README.org][file link]]
     should link to README.org
-- [[file:README.org::#links][file + heading link]]
-    should link to README.org#links -- used to work but was broken sometime after =2020-11-01=
+- [[#links][file + heading link]]
+    should link to #links in the same file (but the link is recognized in Emacs). If the heading is multiple words, attach them with '-'.
 
 ** examples
 


### PR DESCRIPTION
Unfortunately, the link to a section does not work anymore on Github, with the change I made it will still work on GitHub, although not in Emacs. If the heading name is more than a single word, they need to be attached by hyphen, e.g. if the heading is "two word section" the link should be "#two-word-section". I hope you find it helpful.